### PR TITLE
Extract `ConfidentialClaim` reusable claim mechanic. Convert erc20->fherc20 `mapping` to `EnumerableMap`.

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -7,7 +7,7 @@ script = 'script'
 cache_path  = 'cache_forge'
 solc = '0.8.25'
 optimizer = true
-optimizer-runs = 200
+optimizer-runs = 10_000_000
 fs_permissions = [{ access = "read-write", path = "./data" }]
 auto_detect_remappings = false
 

--- a/src/ConfidentialClaim.sol
+++ b/src/ConfidentialClaim.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v5.1.0) (token/ERC20/ERC20.sol)
+
+pragma solidity ^0.8.25;
+
+import {IERC20, IERC20Metadata, ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IFHERC20, FHERC20} from "./FHERC20.sol";
+import {euint128, FHE} from "@fhenixprotocol/cofhe-foundry-mocks/FHE.sol";
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import {console} from "forge-std/console.sol";
+
+contract ConfidentialClaim {
+    using EnumerableSet for EnumerableSet.UintSet;
+
+    struct Claim {
+        uint256 ctHash;
+        uint128 requestedAmount;
+        uint128 decryptedAmount;
+        bool decrypted;
+        address to;
+        bool claimed;
+    }
+
+    mapping(uint256 ctHash => Claim) private _claims;
+    mapping(address => EnumerableSet.UintSet) private _userClaims;
+
+    error ClaimNotFound();
+    error AlreadyClaimed();
+
+    function _createClaim(
+        address to,
+        uint128 value,
+        euint128 claimable
+    ) internal {
+        _claims[euint128.unwrap(claimable)] = Claim({
+            ctHash: euint128.unwrap(claimable),
+            requestedAmount: value,
+            decryptedAmount: 0,
+            decrypted: false,
+            to: to,
+            claimed: false
+        });
+        _userClaims[to].add(euint128.unwrap(claimable));
+    }
+
+    function _handleClaim(
+        uint256 ctHash
+    ) internal returns (Claim memory claim) {
+        claim = _claims[ctHash];
+
+        // Check that the claimable amount exists and has not been claimed yet
+        if (claim.to == address(0)) revert ClaimNotFound();
+        if (claim.claimed) revert AlreadyClaimed();
+
+        // Get the decrypted amount (reverts if the amount is not decrypted yet)
+        uint128 amount = uint128(FHE.getDecryptResult(ctHash));
+
+        // Update the claim
+        claim.decryptedAmount = amount;
+        claim.decrypted = true;
+        claim.claimed = true;
+
+        // Remove the claimable amount from the user's claimable set
+        _userClaims[claim.to].remove(ctHash);
+    }
+
+    function getClaim(uint256 ctHash) public view returns (Claim memory) {
+        Claim memory _claim = _claims[ctHash];
+        (uint256 amount, bool decrypted) = FHE.getDecryptResultSafe(ctHash);
+        _claim.decryptedAmount = uint128(amount);
+        _claim.decrypted = decrypted;
+        return _claim;
+    }
+
+    function getUserClaims(address user) public view returns (Claim[] memory) {
+        uint256[] memory ctHashes = _userClaims[user].values();
+        Claim[] memory userClaims = new Claim[](ctHashes.length);
+        for (uint256 i = 0; i < ctHashes.length; i++) {
+            userClaims[i] = _claims[ctHashes[i]];
+            (uint256 amount, bool decrypted) = FHE.getDecryptResultSafe(
+                ctHashes[i]
+            );
+            userClaims[i].decryptedAmount = uint128(amount);
+            userClaims[i].decrypted = decrypted;
+        }
+        return userClaims;
+    }
+}

--- a/test/ConfidentialERC20.t.sol
+++ b/test/ConfidentialERC20.t.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import {FHERC20} from "./FHERC20_Harness.sol";
 import {ERC20_Harness} from "./ERC20_Harness.sol";
 import {ConfidentialERC20} from "../src/ConfidentialERC20.sol";
 import {TestSetup} from "./TestSetup.sol";
@@ -145,11 +144,11 @@ contract ConfidentialERC20Test is TestSetup {
 
         // Decrypt inserts a claimable amount into the user's claimable set
 
-        uint256[] memory claimable = eBTC.userClaimable(bob);
-        assertEq(claimable.length, 1, "Bob has 1 claimable amount");
-        uint256 claimableCtHash = claimable[0];
+        ConfidentialERC20.Claim[] memory claims = eBTC.getUserClaims(bob);
+        assertEq(claims.length, 1, "Bob has 1 claimable amount");
+        uint256 claimableCtHash = claims[0].ctHash;
         assertEq(
-            eBTC.claimed(claimableCtHash),
+            eBTC.getClaim(claimableCtHash).claimed,
             false,
             "Claimable amount not claimed"
         );

--- a/test/RedactedCore.t.sol
+++ b/test/RedactedCore.t.sol
@@ -77,6 +77,10 @@ contract RedactedCoreTest is TestSetup {
         vm.prank(owner);
         redactedCore.updateStablecoin(address(USDC), true);
 
+        RedactedCore.MappedERC20[] memory deployedFherc20s = redactedCore
+            .getDeployedFherc20s();
+        assertEq(deployedFherc20s.length, 0, "No FHERC20s deployed");
+
         // revert - stablecoin
 
         vm.expectRevert(
@@ -91,6 +95,9 @@ contract RedactedCoreTest is TestSetup {
         );
         redactedCore.deployFherc20(wETH);
 
+        deployedFherc20s = redactedCore.getDeployedFherc20s();
+        assertEq(deployedFherc20s.length, 0, "No FHERC20s deployed");
+
         // success
 
         ERC20_Harness wBTC = new ERC20_Harness("Wrapped BTC", "wBTC", 8);
@@ -99,6 +106,20 @@ contract RedactedCoreTest is TestSetup {
         // Address of ewBTC unknown at this point
         emit RedactedCore.Fherc20Deployed(address(wBTC), address(0));
         redactedCore.deployFherc20(wBTC);
+
+        // Expectations after deploy
+
+        address deployedFherc20 = redactedCore.getFherc20(address(wBTC));
+        assertNotEq(deployedFherc20, address(0), "ewBTC deployed");
+
+        deployedFherc20s = redactedCore.getDeployedFherc20s();
+        assertEq(deployedFherc20s.length, 1, "1 FHERC20 deployed");
+        assertEq(deployedFherc20s[0].erc20, address(wBTC), "wBTC deployed");
+        assertEq(
+            deployedFherc20s[0].fherc20,
+            deployedFherc20,
+            "deployed ewBTC matches"
+        );
 
         // revert - already deployed
 

--- a/test/RedactedCore.t.sol
+++ b/test/RedactedCore.t.sol
@@ -102,7 +102,7 @@ contract RedactedCoreTest is TestSetup {
 
         ERC20_Harness wBTC = new ERC20_Harness("Wrapped BTC", "wBTC", 8);
 
-        vm.expectEmit(true, true, false, false);
+        vm.expectEmit(true, false, false, false);
         // Address of ewBTC unknown at this point
         emit RedactedCore.Fherc20Deployed(address(wBTC), address(0));
         redactedCore.deployFherc20(wBTC);


### PR DESCRIPTION
Requires update to `cofhe-foundry-mocks` dependency to `v0.1.1`.
`cofhe-foundry-mocks` updated to include `getDecryptResultSafe` in this PR: https://github.com/FhenixProtocol/cofhe-foundry-mocks/pull/1

